### PR TITLE
Handle alpha/beta/rc tags too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - master
-    tags: v[0-9]+.[0-9]+.[0-9]+
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This allows the GitHub actions to handle alpha, beta, and release candidate version tags. For example, an alpha tag might look like: `v1.0.0-alpha.0`.