### PR TITLE
Don't install dependencies with `--frozen-lockfile`

### DIFF
--- a/src/steps/install-dependencies.ts
+++ b/src/steps/install-dependencies.ts
@@ -22,24 +22,16 @@ export default async function installDependencies(
 			{
 				title: packageFile.name,
 				task: () =>
-					execa('yarn', [
-						`--mutex`,
-						`file:${configuration.yarnMutexFilePath}`,
-						`install`,
-						`--frozen-lockfile`,
-						`--prefer-offline`,
-					]).catch(yarnErrorCatcher),
+					execa('yarn', [`--mutex`, `file:${configuration.yarnMutexFilePath}`, `install`, `--prefer-offline`]).catch(
+						yarnErrorCatcher
+					),
 			},
 			...testProjectPaths.map((testProjectPath) => ({
 				title: `Project: ${path.basename(testProjectPath)}`,
 				task: () =>
-					execa(
-						'yarn',
-						[`--mutex`, `file:${configuration.yarnMutexFilePath}`, `install`, `--frozen-lockfile`, `--prefer-offline`],
-						{
-							cwd: testProjectPath,
-						}
-					).catch(yarnErrorCatcher),
+					execa('yarn', [`--mutex`, `file:${configuration.yarnMutexFilePath}`, `install`, `--prefer-offline`], {
+						cwd: testProjectPath,
+					}).catch(yarnErrorCatcher),
 			})),
 		],
 		{


### PR DESCRIPTION
It tends to produce errors, including making it impossible to use Rugged inside of Rugged. Maybe we can make this a configurable option in the future, though?
