### PR TITLE
Prep for configurable option `injectAsDevDependency`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ const finalResult: FinalResult = {
 						return yarnErrorCatcher(error);
 					});
 
-					await execa('yarn', [`add`, `link:../..`], {
+					await execa('yarn', [`add`, configuration.injectAsDevDependency ? `--dev` : '', `link:../..`], {
 						cwd: testProjectPath,
 					}).catch(yarnErrorCatcher);
 				},

--- a/src/steps/inject-root-package.ts
+++ b/src/steps/inject-root-package.ts
@@ -76,9 +76,19 @@ export default async function injectRootPackage(
 					testProjectPaths.map((testProjectPath) => ({
 						title: path.basename(testProjectPath),
 						task: () =>
-							execa('yarn', [`--mutex`, `file:${configuration.yarnMutexFilePath}`, `add`, configuration.injectAsDevDependency ? `--dev` : '', `file:${ctx.packagePath}`], {
-								cwd: testProjectPath,
-							}).catch(yarnErrorCatcher),
+							execa(
+								'yarn',
+								[
+									`--mutex`,
+									`file:${configuration.yarnMutexFilePath}`,
+									`add`,
+									configuration.injectAsDevDependency ? `--dev` : '',
+									`file:${ctx.packagePath}`,
+								],
+								{
+									cwd: testProjectPath,
+								}
+							).catch(yarnErrorCatcher),
 					})),
 					{
 						concurrent: true,

--- a/src/steps/inject-root-package.ts
+++ b/src/steps/inject-root-package.ts
@@ -76,7 +76,7 @@ export default async function injectRootPackage(
 					testProjectPaths.map((testProjectPath) => ({
 						title: path.basename(testProjectPath),
 						task: () =>
-							execa('yarn', [`--mutex`, `file:${configuration.yarnMutexFilePath}`, `add`, `file:${ctx.packagePath}`], {
+							execa('yarn', [`--mutex`, `file:${configuration.yarnMutexFilePath}`, `add`, configuration.injectAsDevDependency ? `--dev` : '', `file:${ctx.packagePath}`], {
 								cwd: testProjectPath,
 							}).catch(yarnErrorCatcher),
 					})),

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -3,6 +3,7 @@ import tmp from 'tmp';
 
 // Define what configuration looks like
 export interface Configuration {
+	injectAsDevDependency: boolean;
 	testProjectsDirectory: string;
 	yarnMutexFilePath: string;
 }
@@ -11,6 +12,7 @@ export interface Configuration {
 export default async function configure(): Promise<Configuration> {
 	// Return
 	return {
+		injectAsDevDependency: true,
 		testProjectsDirectory: 'test-projects',
 		yarnMutexFilePath: tmp.fileSync().name,
 	};


### PR DESCRIPTION
This PR lays the groundwork for a new `injectAsDevDependency` option that governs whether the root package should be injected into test projects as a regular dependency or a dev dependency. Right now, it's hardcoded to `true`, for testing purposes, but eventually it will be configurable via the upcoming config file support.