### PR TITLE
Improve verify tests

### DIFF
--- a/src/utils/verify.test.ts
+++ b/src/utils/verify.test.ts
@@ -4,14 +4,19 @@ import path from 'path';
 import { HandledError } from './errors';
 import configure from './configure';
 
-// Mock the function
+// Mock the log function
 console.log = jest.fn();
+
+// Set the absolute path to the test file trees directory
+const testFileTreesPath = path.normalize(path.join(__dirname, '..', '..', 'test-file-trees'));
 
 // Tests
 describe('#verify.packageFile()', () => {
 	it('Catches missing package files', () => {
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'missing-package'));
+
 		expect(() => {
-			verify.packageFile(path.normalize(path.join(__dirname, '..', '..', 'test-file-trees', 'missing-package')));
+			verify.packageFile();
 		}).toThrow(HandledError);
 
 		expect(console.log).toHaveBeenCalledTimes(1);
@@ -19,8 +24,10 @@ describe('#verify.packageFile()', () => {
 	});
 
 	it('Catches package files that are missing a name', () => {
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'package-missing-name'));
+
 		expect(() => {
-			verify.packageFile(path.normalize(path.join(__dirname, '..', '..', 'test-file-trees', 'package-missing-name')));
+			verify.packageFile();
 		}).toThrow(HandledError);
 
 		expect(console.log).toHaveBeenCalledTimes(1);
@@ -28,9 +35,9 @@ describe('#verify.packageFile()', () => {
 	});
 
 	it('Returns parsed version', () => {
-		expect(
-			verify.packageFile(path.normalize(path.join(__dirname, '..', '..', 'test-file-trees', 'primary')))
-		).toStrictEqual({
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'primary'));
+
+		expect(verify.packageFile()).toStrictEqual({
 			name: 'primary',
 		});
 	});
@@ -38,13 +45,12 @@ describe('#verify.packageFile()', () => {
 
 describe('#verify.testProjects()', () => {
 	it('Catches missing package files', async () => {
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'missing-test-projects'));
+
 		const configuration = await configure();
 
 		expect(() => {
-			verify.testProjects(
-				configuration,
-				path.normalize(path.join(__dirname, '..', '..', 'test-file-trees', 'missing-test-projects'))
-			);
+			verify.testProjects(configuration);
 		}).toThrow(HandledError);
 
 		expect(console.log).toHaveBeenCalledTimes(1);
@@ -54,10 +60,10 @@ describe('#verify.testProjects()', () => {
 	});
 
 	it('Returns absolute path', async () => {
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'primary'));
+
 		const configuration = await configure();
 
-		expect(
-			verify.testProjects(configuration, path.normalize(path.join(__dirname, '..', '..', 'test-file-trees', 'primary')))
-		).toMatch(/\/rugged\/test\-file\-trees\/primary\/test\-projects$/);
+		expect(verify.testProjects(configuration)).toMatch(/\/rugged\/test\-file\-trees\/primary\/test\-projects$/);
 	});
 });

--- a/src/utils/verify.ts
+++ b/src/utils/verify.ts
@@ -13,13 +13,11 @@ export interface PackageFile {
 /** Helper functions for verifying things */
 const verify = {
 	/** Make sure package file exists and it has a name */
-	packageFile(cwd?: string): PackageFile {
-		const packageFilePath = path.join(cwd ?? process.cwd(), 'package.json');
+	packageFile(): PackageFile {
+		const packageFilePath = path.join(process.cwd(), 'package.json');
 
 		if (!fs.existsSync(packageFilePath)) {
-			console.log(
-				chalk.red(`\nCouldn’t find ${chalk.bold('package.json')} in this directory (${cwd ?? process.cwd()})\n`)
-			);
+			console.log(chalk.red(`\nCouldn’t find ${chalk.bold('package.json')} in this directory (${process.cwd()})\n`));
 			throw new HandledError();
 		}
 
@@ -39,15 +37,15 @@ const verify = {
 	},
 
 	/** Verify that the test projects exist */
-	testProjects(configuration: Configuration, cwd?: string): string {
-		const absolutePath = path.join(cwd ?? process.cwd(), configuration.testProjectsDirectory);
+	testProjects(configuration: Configuration): string {
+		const absolutePath = path.join(process.cwd(), configuration.testProjectsDirectory);
 
 		if (!fs.existsSync(absolutePath)) {
 			console.log(
 				chalk.red(
-					`\nCouldn’t find ${chalk.bold(`./${configuration.testProjectsDirectory}/`)} in this directory (${
-						cwd ?? process.cwd()
-					})\n`
+					`\nCouldn’t find ${chalk.bold(
+						`./${configuration.testProjectsDirectory}/`
+					)} in this directory (${process.cwd()})\n`
 				)
 			);
 


### PR DESCRIPTION
This improves the testing of the `verify.XXX()` functions in two major ways:

1. It eliminates the `cwd` parameters, and instead relies on Jest to mock the return value of `process.cwd()`
2. It reduces the redundancy of forming the path to get to the test file trees directory