### PR TITLE
Only compile the root package if a `compile` script is present

### DIFF
--- a/src/steps/inject-root-package.ts
+++ b/src/steps/inject-root-package.ts
@@ -21,6 +21,7 @@ export default async function injectRootPackage(
 	const tasks = new Listr([
 		{
 			title: `Compiling`,
+			skip: () => !Object.keys(packageFile.scripts ?? {}).includes('compile'),
 			task: () => execa('yarn', ['compile']).catch(yarnErrorCatcher),
 		},
 		{

--- a/src/utils/verify.ts
+++ b/src/utils/verify.ts
@@ -8,6 +8,9 @@ import { HandledError } from './errors';
 // Define what a package file should look like
 export interface PackageFile {
 	name: string;
+	scripts?: {
+		[script: string]: string;
+	};
 }
 
 /** Helper functions for verifying things */


### PR DESCRIPTION
This updates the "inject root package" step to only compile the root package if a `compile` script is present. This allows Rugged to work with packages that aren't compiled, like vanilla JS projects.

_Note: eventually we'll need to make the `compile` name configurable, but that will come later._