### PR TITLE
Ability to choose whether to run tests in parallel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ const finalResult: FinalResult = {
 	// Trigger each step
 	await installDependencies(packageFile, testProjectPaths);
 	await injectRootPackage(packageFile, testProjectPaths);
-	await testProjects(testProjectPaths, finalResult);
+	await testProjects(testProjectPaths, finalResult, config.testInParallel);
 })()
 	.catch((error) => {
 		// Remember that we encountered an error

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ const finalResult: FinalResult = {
 	// Trigger each step
 	await installDependencies(packageFile, testProjectPaths);
 	await injectRootPackage(packageFile, testProjectPaths);
-	await testProjects(testProjectPaths, finalResult, config.testInParallel);
+	await testProjects(testProjectPaths, finalResult);
 })()
 	.catch((error) => {
 		// Remember that we encountered an error

--- a/src/steps/test-projects.ts
+++ b/src/steps/test-projects.ts
@@ -4,14 +4,14 @@ import Listr from 'listr';
 import path from 'path';
 import { FinalResult } from '..';
 import { HandledError } from '../utils/errors';
+import getConfig from '../utils/get-config';
 import printHeader from '../utils/print-header';
 
 /** Installs dependencies into the root project and test projects */
-export default async function testProjects(
-	testProjectPaths: string[],
-	finalResult: FinalResult,
-	testInParallel: boolean
-) {
+export default async function testProjects(testProjectPaths: string[], finalResult: FinalResult) {
+	// Get the configuration for testing in parallel
+	const { testInParallel } = await getConfig();
+
 	// Print section header
 	printHeader('Testing projects');
 

--- a/src/steps/test-projects.ts
+++ b/src/steps/test-projects.ts
@@ -7,7 +7,11 @@ import { HandledError } from '../utils/errors';
 import printHeader from '../utils/print-header';
 
 /** Installs dependencies into the root project and test projects */
-export default async function testProjects(testProjectPaths: string[], finalResult: FinalResult) {
+export default async function testProjects(
+	testProjectPaths: string[],
+	finalResult: FinalResult,
+	testInParallel: boolean
+) {
 	// Print section header
 	printHeader('Testing projects');
 
@@ -31,7 +35,7 @@ export default async function testProjects(testProjectPaths: string[], finalResu
 				}),
 		})),
 		{
-			concurrent: true,
+			concurrent: testInParallel,
 			exitOnError: false,
 		}
 	);

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -17,6 +17,9 @@ export interface Config {
 	/** An absolute path to the file Yarn commands should use for the `--mutex` flag. Defaults to a randomly
 	 * generated temporary file. */
 	yarnMutexFilePath: string;
+
+	/** Whether to run tests in parallel */
+	testInParallel: boolean;
 }
 
 // Initialize
@@ -34,6 +37,7 @@ export default async function getConfig(reconstruct?: true): Promise<Config> {
 		injectAsDevDependency: false,
 		testProjectsDirectory: 'test-projects',
 		yarnMutexFilePath: tmp.fileSync().name,
+		testInParallel: true,
 	};
 
 	// Initialize custom config
@@ -48,6 +52,7 @@ export default async function getConfig(reconstruct?: true): Promise<Config> {
 		injectAsDevDependency: (value) => typeof value === 'boolean',
 		testProjectsDirectory: (value) => typeof value === 'string' && fs.existsSync(value),
 		yarnMutexFilePath: (value) => typeof value === 'string' && fs.existsSync(value),
+		testInParallel: (value) => typeof value === 'boolean',
 	};
 
 	// Initialize paths to possible config files


### PR DESCRIPTION
This pull request adds a configuration option to decide whether tests will run in parallel, which defaults to true. It also implements the behavior that corresponds to the configuration setting when tests are run.

Closes #8 