### PR TITLE
Add ability to specify compile command

### DIFF
--- a/src/steps/inject-root-package.ts
+++ b/src/steps/inject-root-package.ts
@@ -20,8 +20,8 @@ export default async function injectRootPackage(packageFile: PackageFile, testPr
 	const tasks = new Listr([
 		{
 			title: `Compiling`,
-			skip: () => !Object.keys(packageFile.scripts ?? {}).includes('compile'),
-			task: () => execa('yarn', ['compile']).catch(yarnErrorCatcher),
+			skip: () => !Object.keys(packageFile.scripts ?? {}).includes(config.compileScriptName),
+			task: () => execa('yarn', [config.compileScriptName]).catch(yarnErrorCatcher),
 		},
 		{
 			title: `Packaging`,

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -21,7 +21,7 @@ export interface Config {
 	/** Whether to run tests in parallel */
 	testInParallel: boolean;
 
-	/** Which script to run to compile project. Defaults to `compile`. */
+	/** Which `package.json` script to run to compile the root project. Defaults to `compile`; however, the compilation step will be skipped if the script does not exist. */
 	compileScriptName: string;
 }
 

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -20,6 +20,9 @@ export interface Config {
 
 	/** Whether to run tests in parallel */
 	testInParallel: boolean;
+
+	/** Which script to run to compile project. Defaults to `compile`. */
+	compileScriptName: string;
 }
 
 // Initialize
@@ -38,6 +41,7 @@ export default async function getConfig(reconstruct?: true): Promise<Config> {
 		testProjectsDirectory: 'test-projects',
 		yarnMutexFilePath: tmp.fileSync().name,
 		testInParallel: true,
+		compileScriptName: 'compile',
 	};
 
 	// Initialize custom config
@@ -53,6 +57,7 @@ export default async function getConfig(reconstruct?: true): Promise<Config> {
 		testProjectsDirectory: (value) => typeof value === 'string' && fs.existsSync(value),
 		yarnMutexFilePath: (value) => typeof value === 'string' && fs.existsSync(value),
 		testInParallel: (value) => typeof value === 'boolean',
+		compileScriptName: (value) => typeof value === 'string',
 	};
 
 	// Initialize paths to possible config files


### PR DESCRIPTION
This pull request adds the ability to specify a custom compile command, which when not specified defaults to `compile`.

Closes #22 