### PR TITLE
Add ability to print successful output option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ const finalResult: FinalResult = {
 		// Loop over each successful test
 		for (const successfulTest of finalResult.successfulTests) {
 			// Print section header
-			console.log(`\n${chalk.inverse(chalk.white(chalk.bold(` Output from: ${successfulTest.project} `)))}\n`);
+			console.log(`\n${chalk.inverse(chalk.green(chalk.bold(` Output from: ${successfulTest.project} `)))}\n`);
 
 			// Print output
 			console.log(successfulTest.output.trim());

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,11 +28,16 @@ export interface FinalResult {
 		project: string;
 		output: string;
 	}[];
+	successfulTests: {
+		project: string;
+		output: string;
+	}[];
 }
 
 const finalResult: FinalResult = {
 	errorEncountered: false,
 	failedTests: [],
+	successfulTests: [],
 };
 
 // Wrap everything in a self-executing async function

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,15 @@ const finalResult: FinalResult = {
 
 		await tasks.run();
 
+		// Loop over each successful test
+		for (const successfulTest of finalResult.successfulTests) {
+			// Print section header
+			console.log(`\n${chalk.inverse(chalk.white(chalk.bold(` Output from: ${successfulTest.project} `)))}\n`);
+
+			// Print output
+			console.log(successfulTest.output.trim());
+		}
+
 		// Loop over each failed test
 		for (const failedTest of finalResult.failedTests) {
 			// Print section header

--- a/src/steps/test-projects.ts
+++ b/src/steps/test-projects.ts
@@ -24,17 +24,15 @@ export default async function testProjects(testProjectPaths: string[], finalResu
 					cwd: testProjectPath,
 					all: true,
 				})
-					.then(
-						printSuccessfulOutput
-							? (result) => {
-									// Add to final result
-									finalResult.successfulTests.push({
-										project: path.basename(testProjectPath),
-										output: result.all ?? 'No output...',
-									});
-							  }
-							: undefined
-					)
+					.then((result) => {
+						if (printSuccessfulOutput) {
+							// Add to final result
+							finalResult.successfulTests.push({
+								project: path.basename(testProjectPath),
+								output: result.all ?? 'No output...',
+							});
+						}
+					})
 					.catch((error) => {
 						// Add to final result
 						finalResult.failedTests.push({

--- a/src/steps/test-projects.ts
+++ b/src/steps/test-projects.ts
@@ -10,7 +10,7 @@ import printHeader from '../utils/print-header';
 /** Installs dependencies into the root project and test projects */
 export default async function testProjects(testProjectPaths: string[], finalResult: FinalResult) {
 	// Get the configuration for testing in parallel
-	const { testInParallel } = await getConfig();
+	const { testInParallel, printSuccessfulOutput } = await getConfig();
 
 	// Print section header
 	printHeader('Testing projects');
@@ -23,16 +23,30 @@ export default async function testProjects(testProjectPaths: string[], finalResu
 				execa('yarn', [`test`], {
 					cwd: testProjectPath,
 					all: true,
-				}).catch((error) => {
-					// Add to final result
-					finalResult.failedTests.push({
-						project: path.basename(testProjectPath),
-						output: error.all ?? 'No output...',
-					});
+				}).then(
+					printSuccessfulOutput
+						? (result) => {
+								// Add to final result
+								finalResult.successfulTests.push({
+									project: path.basename(testProjectPath),
+									output: result.all ?? 'No output...',
+								});
 
-					// Throw error that Listr will pick up
-					throw new Error('Output will be printed below');
-				}),
+								// Throw error that Listr will pick up
+								throw new Error('Output will be printed below');
+						  }
+						: undefined,
+					(error) => {
+						// Add to final result
+						finalResult.failedTests.push({
+							project: path.basename(testProjectPath),
+							output: error.all ?? 'No output...',
+						});
+
+						// Throw error that Listr will pick up
+						throw new Error('Output will be printed below');
+					}
+				),
 		})),
 		{
 			concurrent: testInParallel,

--- a/src/steps/test-projects.ts
+++ b/src/steps/test-projects.ts
@@ -32,9 +32,6 @@ export default async function testProjects(testProjectPaths: string[], finalResu
 										project: path.basename(testProjectPath),
 										output: result.all ?? 'No output...',
 									});
-
-									// Throw error that Listr will pick up
-									throw new Error('Output will be printed below');
 							  }
 							: undefined
 					)

--- a/src/steps/test-projects.ts
+++ b/src/steps/test-projects.ts
@@ -23,20 +23,22 @@ export default async function testProjects(testProjectPaths: string[], finalResu
 				execa('yarn', [`test`], {
 					cwd: testProjectPath,
 					all: true,
-				}).then(
-					printSuccessfulOutput
-						? (result) => {
-								// Add to final result
-								finalResult.successfulTests.push({
-									project: path.basename(testProjectPath),
-									output: result.all ?? 'No output...',
-								});
+				})
+					.then(
+						printSuccessfulOutput
+							? (result) => {
+									// Add to final result
+									finalResult.successfulTests.push({
+										project: path.basename(testProjectPath),
+										output: result.all ?? 'No output...',
+									});
 
-								// Throw error that Listr will pick up
-								throw new Error('Output will be printed below');
-						  }
-						: undefined,
-					(error) => {
+									// Throw error that Listr will pick up
+									throw new Error('Output will be printed below');
+							  }
+							: undefined
+					)
+					.catch((error) => {
 						// Add to final result
 						finalResult.failedTests.push({
 							project: path.basename(testProjectPath),
@@ -45,8 +47,7 @@ export default async function testProjects(testProjectPaths: string[], finalResu
 
 						// Throw error that Listr will pick up
 						throw new Error('Output will be printed below');
-					}
-				),
+					}),
 		})),
 		{
 			concurrent: testInParallel,

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -21,7 +21,7 @@ export interface Config {
 	/** Whether to run tests in parallel */
 	testInParallel: boolean;
 
-	/** Whether to print successful test output*/
+	/** Whether to print successful test output, in addition to failed test output. Defaults to `false`. */
 	printSuccessfulOutput: boolean;
 }
 

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -20,6 +20,9 @@ export interface Config {
 
 	/** Whether to run tests in parallel */
 	testInParallel: boolean;
+
+	/** Whether to print successful test output*/
+	printSuccessfulOutput: boolean;
 }
 
 // Initialize
@@ -38,6 +41,7 @@ export default async function getConfig(reconstruct?: true): Promise<Config> {
 		testProjectsDirectory: 'test-projects',
 		yarnMutexFilePath: tmp.fileSync().name,
 		testInParallel: true,
+		printSuccessfulOutput: false,
 	};
 
 	// Initialize custom config
@@ -53,6 +57,7 @@ export default async function getConfig(reconstruct?: true): Promise<Config> {
 		testProjectsDirectory: (value) => typeof value === 'string' && fs.existsSync(value),
 		yarnMutexFilePath: (value) => typeof value === 'string' && fs.existsSync(value),
 		testInParallel: (value) => typeof value === 'boolean',
+		printSuccessfulOutput: (value) => typeof value === 'boolean',
 	};
 
 	// Initialize paths to possible config files


### PR DESCRIPTION
This pull request adds a configuration option to print successful test output which defaults to `false`.

![image](https://user-images.githubusercontent.com/3850064/110643568-d769e780-8179-11eb-99cf-4d801640f478.png)

Closes #25 