### PR TITLE
Refactor threading of package file throughout module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import printHeader from './utils/print-header';
 import installDependencies from './steps/install-dependencies';
 import injectRootPackage from './steps/inject-root-package';
 import testProjects from './steps/test-projects';
+import getPackageFile from './utils/get-package-file';
 
 // Export a type used for TypeScript config files
 type PartialConfig = Partial<Config>;
@@ -40,8 +41,10 @@ const finalResult: FinalResult = {
 	// Get the config
 	const config = await getConfig();
 
+	// Get the package file
+	const packageFile = getPackageFile();
+
 	// Verification
-	const packageFile = verify.packageFile();
 	const absolutePath = verify.testProjects(config);
 
 	// Determine test project paths
@@ -103,8 +106,8 @@ const finalResult: FinalResult = {
 	};
 
 	// Trigger each step
-	await installDependencies(packageFile, testProjectPaths);
-	await injectRootPackage(packageFile, testProjectPaths);
+	await installDependencies(testProjectPaths);
+	await injectRootPackage(testProjectPaths);
 	await testProjects(testProjectPaths, finalResult);
 })()
 	.catch((error) => {

--- a/src/steps/inject-root-package.ts
+++ b/src/steps/inject-root-package.ts
@@ -4,12 +4,15 @@ import Listr from 'listr';
 import path from 'path';
 import { HandledError, yarnErrorCatcher } from '../utils/errors';
 import printHeader from '../utils/print-header';
-import { PackageFile } from '../utils/verify';
 import tmp from 'tmp';
 import getConfig from '../utils/get-config';
+import getPackageFile from '../utils/get-package-file';
 
 /** Installs dependencies into the root project and test projects */
-export default async function injectRootPackage(packageFile: PackageFile, testProjectPaths: string[]) {
+export default async function injectRootPackage(testProjectPaths: string[]) {
+	// Get the package file
+	const packageFile = getPackageFile();
+
 	// Print section header
 	printHeader(`Injecting ${packageFile.name}`);
 

--- a/src/steps/install-dependencies.ts
+++ b/src/steps/install-dependencies.ts
@@ -4,13 +4,16 @@ import Listr from 'listr';
 import path from 'path';
 import { HandledError, yarnErrorCatcher } from '../utils/errors';
 import getConfig from '../utils/get-config';
+import getPackageFile from '../utils/get-package-file';
 import printHeader from '../utils/print-header';
-import { PackageFile } from '../utils/verify';
 
 /** Installs dependencies into the root project and test projects */
-export default async function installDependencies(packageFile: PackageFile, testProjectPaths: string[]) {
+export default async function installDependencies(testProjectPaths: string[]) {
 	// Print section header
 	printHeader('Installing dependencies');
+
+	// Get the package file
+	const packageFile = getPackageFile();
 
 	// Get config
 	const config = await getConfig();

--- a/src/utils/get-package-file.test.ts
+++ b/src/utils/get-package-file.test.ts
@@ -7,16 +7,16 @@ import getPackageFile from './get-package-file';
 const testFileTreesPath = path.normalize(path.join(__dirname, '..', '..', 'test-file-trees'));
 
 // Tests
-describe('#getPackageFile()', () => {
+describe('#getPackageFile(true)', () => {
 	it('Catches missing package files', () => {
 		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'missing-package'));
 
 		expect(() => {
-			getPackageFile();
+			getPackageFile(true);
 		}).toThrow(PrintableError);
 
 		expect(() => {
-			getPackageFile();
+			getPackageFile(true);
 		}).toThrow('Couldn’t find package.json in this directory');
 	});
 
@@ -24,11 +24,11 @@ describe('#getPackageFile()', () => {
 		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'package-missing-name'));
 
 		expect(() => {
-			getPackageFile();
+			getPackageFile(true);
 		}).toThrow(PrintableError);
 
 		expect(() => {
-			getPackageFile();
+			getPackageFile(true);
 		}).toThrow('The package.json is missing a name');
 	});
 
@@ -36,18 +36,18 @@ describe('#getPackageFile()', () => {
 		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'package-missing-version'));
 
 		expect(() => {
-			getPackageFile();
+			getPackageFile(true);
 		}).toThrow(PrintableError);
 
 		expect(() => {
-			getPackageFile();
+			getPackageFile(true);
 		}).toThrow('The package.json is missing a version');
 	});
 
 	it('Returns parsed version', () => {
 		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'primary'));
 
-		expect(getPackageFile()).toStrictEqual({
+		expect(getPackageFile(true)).toStrictEqual({
 			name: 'primary',
 			version: '1.2.3',
 		});

--- a/src/utils/get-package-file.test.ts
+++ b/src/utils/get-package-file.test.ts
@@ -1,0 +1,55 @@
+// Imports
+import path from 'path';
+import { PrintableError } from './errors';
+import getPackageFile from './get-package-file';
+
+// Set the absolute path to the test file trees directory
+const testFileTreesPath = path.normalize(path.join(__dirname, '..', '..', 'test-file-trees'));
+
+// Tests
+describe('#getPackageFile()', () => {
+	it('Catches missing package files', () => {
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'missing-package'));
+
+		expect(() => {
+			getPackageFile();
+		}).toThrow(PrintableError);
+
+		expect(() => {
+			getPackageFile();
+		}).toThrow('Couldn’t find package.json in this directory');
+	});
+
+	it('Catches package files that are missing a name', () => {
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'package-missing-name'));
+
+		expect(() => {
+			getPackageFile();
+		}).toThrow(PrintableError);
+
+		expect(() => {
+			getPackageFile();
+		}).toThrow('The package.json is missing a name');
+	});
+
+	it('Catches package files that are missing a version', () => {
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'package-missing-version'));
+
+		expect(() => {
+			getPackageFile();
+		}).toThrow(PrintableError);
+
+		expect(() => {
+			getPackageFile();
+		}).toThrow('The package.json is missing a version');
+	});
+
+	it('Returns parsed version', () => {
+		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'primary'));
+
+		expect(getPackageFile()).toStrictEqual({
+			name: 'primary',
+			version: '1.2.3',
+		});
+	});
+});

--- a/src/utils/get-package-file.ts
+++ b/src/utils/get-package-file.ts
@@ -1,0 +1,46 @@
+// Imports
+import path from 'path';
+import fs from 'fs';
+import chalk from './chalk';
+import { PrintableError } from './errors';
+
+// Define what a package file should look like
+export interface PackageFile {
+	version: string;
+	name: string;
+	scripts?: {
+		[script: string]: string;
+	};
+}
+
+// Initialize
+let parsedFile: PackageFile | undefined = undefined;
+
+/** Retrieve and validate package file */
+export default function getPackageFile(): PackageFile {
+	if (typeof parsedFile === 'object') {
+		return parsedFile;
+	}
+
+	const packageFilePath = path.join(process.cwd(), 'package.json');
+
+	if (!fs.existsSync(packageFilePath)) {
+		throw new PrintableError(`Couldn’t find ${chalk.bold('package.json')} in this directory (${process.cwd()})`);
+	}
+
+	parsedFile = require(packageFilePath);
+
+	if (typeof parsedFile !== 'object' || !parsedFile) {
+		throw new PrintableError(`The ${chalk.bold('package.json')} file doesn’t appear to be an object`);
+	}
+
+	if (typeof parsedFile.name !== 'string') {
+		throw new PrintableError(`The ${chalk.bold('package.json')} is missing a name`);
+	}
+
+	if (typeof parsedFile.version !== 'string') {
+		throw new PrintableError(`The ${chalk.bold('package.json')} is missing a version`);
+	}
+
+	return parsedFile;
+}

--- a/src/utils/get-package-file.ts
+++ b/src/utils/get-package-file.ts
@@ -17,8 +17,8 @@ export interface PackageFile {
 let parsedFile: PackageFile | undefined = undefined;
 
 /** Retrieve and validate package file */
-export default function getPackageFile(): PackageFile {
-	if (typeof parsedFile === 'object') {
+export default function getPackageFile(refresh?: true): PackageFile {
+	if (typeof parsedFile === 'object' && refresh !== true) {
 		return parsedFile;
 	}
 

--- a/src/utils/verify.test.ts
+++ b/src/utils/verify.test.ts
@@ -8,53 +8,6 @@ import { PrintableError } from './errors';
 const testFileTreesPath = path.normalize(path.join(__dirname, '..', '..', 'test-file-trees'));
 
 // Tests
-describe('#verify.packageFile()', () => {
-	it('Catches missing package files', () => {
-		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'missing-package'));
-
-		expect(() => {
-			verify.packageFile();
-		}).toThrow(PrintableError);
-
-		expect(() => {
-			verify.packageFile();
-		}).toThrow('Couldn’t find package.json in this directory');
-	});
-
-	it('Catches package files that are missing a name', () => {
-		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'package-missing-name'));
-
-		expect(() => {
-			verify.packageFile();
-		}).toThrow(PrintableError);
-
-		expect(() => {
-			verify.packageFile();
-		}).toThrow('The package.json is missing a name');
-	});
-
-	it('Catches package files that are missing a version', () => {
-		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'package-missing-version'));
-
-		expect(() => {
-			verify.packageFile();
-		}).toThrow(PrintableError);
-
-		expect(() => {
-			verify.packageFile();
-		}).toThrow('The package.json is missing a version');
-	});
-
-	it('Returns parsed version', () => {
-		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'primary'));
-
-		expect(verify.packageFile()).toStrictEqual({
-			name: 'primary',
-			version: '1.2.3',
-		});
-	});
-});
-
 describe('#verify.testProjects()', () => {
 	it('Catches missing package files', async () => {
 		jest.spyOn(process, 'cwd').mockReturnValue(path.join(testFileTreesPath, 'missing-test-projects'));

--- a/src/utils/verify.ts
+++ b/src/utils/verify.ts
@@ -5,41 +5,8 @@ import chalk from './chalk';
 import { Config } from './get-config';
 import { PrintableError } from './errors';
 
-// Define what a package file should look like
-export interface PackageFile {
-	name: string;
-	scripts?: {
-		[script: string]: string;
-	};
-}
-
 /** Helper functions for verifying things */
 const verify = {
-	/** Make sure package file exists and it has a name */
-	packageFile(): PackageFile {
-		const packageFilePath = path.join(process.cwd(), 'package.json');
-
-		if (!fs.existsSync(packageFilePath)) {
-			throw new PrintableError(`Couldn’t find ${chalk.bold('package.json')} in this directory (${process.cwd()})`);
-		}
-
-		const parsedFile = require(packageFilePath);
-
-		if (typeof parsedFile !== 'object' || !parsedFile) {
-			throw new PrintableError(`The ${chalk.bold('package.json')} file doesn’t appear to be an object`);
-		}
-
-		if (typeof parsedFile.name !== 'string') {
-			throw new PrintableError(`The ${chalk.bold('package.json')} is missing a name`);
-		}
-
-		if (typeof parsedFile.version !== 'string') {
-			throw new PrintableError(`The ${chalk.bold('package.json')} is missing a version`);
-		}
-
-		return parsedFile;
-	},
-
 	/** Verify that the test projects exist */
 	testProjects(config: Config): string {
 		const absolutePath = path.join(process.cwd(), config.testProjectsDirectory);


### PR DESCRIPTION
This pull request refactors our approach to handing the `package.json` contents between different pieces of the module. It adds a function `getPackageFile` that replaces `verify.packageFile`, and stores the package file contents for subsequent requests in memory.

Closes #34 
