### PR TITLE
Write most of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,12 @@
 
 Rugged orchestrates testing JavaScript packages across the variety of environments and contexts where it’s actually being used, with the files that will actually be published.
 
+- ⚡️ Performance design
+- 🔧 Easily configurable
 - 📦 Written entirely in TypeScript
 - 🔬 Thoroughly tested
-- ⚡️ Zero dependencies
-- 🤝 Promise-based design
 - ✨ Tiny size
-- 🌎 Works in Node.js and browsers
-- 📖 Thoroughly documented
+- 📖 Well documented
 
 ## The problem
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Rugged orchestrates testing JavaScript packages across the variety of environmen
 - ✨ Tiny size
 - 📖 Well documented
 
-![Screen recording](https://user-images.githubusercontent.com/3850064/110968246-ea68ed00-831c-11eb-8d1f-68136f71cccf.gif)
+![Screen recording](https://user-images.githubusercontent.com/3850064/110968462-2bf99800-831d-11eb-98f8-b3ded33a08a8.gif)
 
 ## The problem
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     </a>
 </p>
 
-Rugged orchestrates testing JavaScript packages across the variety of real-world environments and contexts where it’s being used, with the files that will actually be published.
+Rugged orchestrates testing JavaScript packages across the variety of real-world environments and contexts where it’s actually being used, with the files that will actually be published.
 
 - ⚡️ Performant design
 - 🔧 Configurable

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
     </a>
 </p>
 
-Rugged orchestrates testing JavaScript packages across the variety of environments and contexts where it’s actually being used, with the files that will actually be published.
+Rugged orchestrates testing JavaScript packages across the variety of real-world environments and contexts where it’s being used, with the files that will actually be published.
 
-- ⚡️ Performance design
-- 🔧 Easily configurable
+- ⚡️ Performant design
+- 🔧 Configurable
 - 📦 Written entirely in TypeScript
 - 🌎 Works in CLI and CI environments
 - 🔬 Thoroughly tested

--- a/README.md
+++ b/README.md
@@ -1,18 +1,71 @@
 # <div align="center">Rugged</div>
 
 <p align="center">
-<img alt="npm bundle size" src="https://img.shields.io/bundlephobia/min/rugged">
-<img alt="Codecov" src="https://img.shields.io/codecov/c/github/sparksuite/rugged">
-<img alt="npm" src="https://img.shields.io/npm/dw/rugged">
-<img alt="npm" src="https://img.shields.io/npm/v/rugged">
-<img alt="npm" src="https://img.shields.io/npm/l/rugged">
+    <a href="https://www.npmjs.com/package/rugged" target="_blank" rel="noopener noreferrer">
+        <img alt="npm bundle size" src="https://img.shields.io/bundlephobia/min/rugged">
+    </a>
+    <a href="https://app.codecov.io/gh/sparksuite/rugged/branch/master" target="_blank" rel="noopener noreferrer">
+        <img alt="Codecov coverage" src="https://img.shields.io/codecov/c/github/sparksuite/rugged">
+    </a>
+    <a href="https://www.npmjs.com/package/rugged" target="_blank" rel="noopener noreferrer">
+        <img alt="npm downloads" src="https://img.shields.io/npm/dw/rugged">
+    </a>
+    <a href="https://www.npmjs.com/package/rugged" target="_blank" rel="noopener noreferrer">
+        <img alt="npm release" src="https://img.shields.io/npm/v/rugged">
+    </a>
+    <a href="https://github.com/sparksuite/rugged/blob/master/LICENSE" target="_blank" rel="noopener noreferrer">
+        <img alt="license" src="https://img.shields.io/npm/l/rugged">
+    </a>
 </p>
 
-TODO
+Rugged orchestrates testing JavaScript packages across the variety of environments and contexts where it’s actually being used, with the files that will actually be published.
+
+- 📦 Written entirely in TypeScript
+- 🔬 Thoroughly tested
+- ⚡️ Zero dependencies
+- 🤝 Promise-based design
+- ✨ Tiny size
+- 🌎 Works in Node.js and browsers
+- 📖 Thoroughly documented
+
+## The problem
+
+Today, people can consume your package in many contexts—in Node.js, in a browser, in an ECMAScript module, in a Common JS module, within a library (e.g., React, Angular, etc.), with assistance from compilers/transpilers/bundlers (e.g., TypeScript, Babel, Webpack, etc.), even inside test runners (e.g., Jest, Mocha, etc.). Each of these contexts has a unique set of capabilities, limitations, requirements, global variables, etc. that could impact or even break your package’s behavior.
+
+Further, testing often only occurs against the source files that are available in the repository, which is problematic in two ways… First, tools may manipulate the source code in such a way that the compiled/transpiled/bundled version behaves slightly differently than the source code. Second, misconfigurations in your `package.json` may cause necessary files to be excluded from the published version of your package.
+
+## How Rugged helps
+
+Rugged facilitates testing your package in the environments and contexts where your package will be used, using the files that would be published (i.e., the compiled/transpiled/bundled files that are included according to your `package.json` settings).
+
+You do this by creating a variety of minimal test projects that mimic what projects that use your package could look like. These test projects live in your package’s repository and simply need a `test` script in their `package.json` files. Rugged will run these scripts in each test project to verify your package works as expected in each environment/context.
 
 ## Quick start
 
-TODO
+Install with Yarn or npm:
+
+```
+yarn add --dev rugged
+```
+
+```
+npm install --save-dev rugged
+```
+
+Create a `test-projects/` directory with at least one test project inside of it (check out [Rugged’s test project directory](https://github.com/sparksuite/rugged/tree/master/test-projects) for examples).
+
+Add `rugged` to the `test` script in the `package.json` file:
+
+```json
+{
+    "scripts": {
+        "test": "rugged", // If a `test` script doesn’t yet exist
+        "test": "... && rugged" // If there’s already a `test` script
+    }
+}
+```
+
+Done!
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Add `rugged` to the `test` script in the `package.json` file:
 ```json
 {
     "scripts": {
-        "test": "rugged", // If a `test` script doesn’t yet exist
-        "test": "... && rugged" // If there’s already a `test` script
+        "test": "rugged"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Rugged orchestrates testing JavaScript packages across the variety of environmen
 - ✨ Tiny size
 - 📖 Well documented
 
+![Screen recording](https://user-images.githubusercontent.com/3850064/110968246-ea68ed00-831c-11eb-8d1f-68136f71cccf.gif)
+
 ## The problem
 
 Today, people can consume your package in many contexts—in Node.js, in a browser, in an ECMAScript module, in a Common JS module, within a library (e.g., React, Angular, etc.), with assistance from compilers/transpilers/bundlers (e.g., TypeScript, Babel, Webpack, etc.), even inside test runners (e.g., Jest, Mocha, etc.). Each of these contexts has a unique set of capabilities, limitations, requirements, global variables, etc. that could impact or even break your package’s behavior.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # <div align="center">Rugged</div>
 
 <p align="center">
-    <a href="https://www.npmjs.com/package/rugged" target="_blank" rel="noopener noreferrer">
+    <a href="https://www.npmjs.com/package/rugged">
         <img alt="npm bundle size" src="https://img.shields.io/bundlephobia/min/rugged">
     </a>
-    <a href="https://app.codecov.io/gh/sparksuite/rugged/branch/master" target="_blank" rel="noopener noreferrer">
+    <a href="https://app.codecov.io/gh/sparksuite/rugged/branch/master">
         <img alt="Codecov coverage" src="https://img.shields.io/codecov/c/github/sparksuite/rugged">
     </a>
-    <a href="https://www.npmjs.com/package/rugged" target="_blank" rel="noopener noreferrer">
+    <a href="https://www.npmjs.com/package/rugged">
         <img alt="npm downloads" src="https://img.shields.io/npm/dw/rugged">
     </a>
-    <a href="https://www.npmjs.com/package/rugged" target="_blank" rel="noopener noreferrer">
+    <a href="https://www.npmjs.com/package/rugged">
         <img alt="npm release" src="https://img.shields.io/npm/v/rugged">
     </a>
-    <a href="https://github.com/sparksuite/rugged/blob/master/LICENSE" target="_blank" rel="noopener noreferrer">
+    <a href="https://github.com/sparksuite/rugged/blob/master/LICENSE">
         <img alt="license" src="https://img.shields.io/npm/l/rugged">
     </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Rugged orchestrates testing JavaScript packages across the variety of environmen
 - ⚡️ Performance design
 - 🔧 Easily configurable
 - 📦 Written entirely in TypeScript
+- 🌎 Works in CLI and CI environments
 - 🔬 Thoroughly tested
 - ✨ Tiny size
 - 📖 Well documented


### PR DESCRIPTION
This PR introduces the initial version of the README, although there will almost certainly be changes introduced later. Off the top of my head, we may want to add the logo once that's designed, along with a link to the documentation for test projects, once that's written.

Closes #23  
Closes #45 