### PR TITLE
Explicitly upgrade Typescript

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -38,6 +38,6 @@
 		"@types/react": "^17.0.2",
 		"@types/react-helmet": "^6.1.0",
 		"@types/react-router-dom": "^5.1.7",
-		"typescript": "^4.2.2"
+		"typescript": "^4.9.3"
 	}
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7266,7 +7266,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.2.2:
+typescript@^4.9.3:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
   integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==


### PR DESCRIPTION
While working on #105 I had encountered a bug with resolving webpack's typings, one of the resolutions I tried while working on it was bumping the version of Typescript to current. That worked and I moved on, later after upgrading more packages I wondered if I really needed to bump the version of Typescript so I bumped it back down to the old version, everything looked like it still worked so I carried on assuming that change was unneeded now that all the correct packages were upgraded. Unfortunately I did not realize that the version of Typescript that was in the package.json actually allowed the most recent version of Typescript to be resolved, so the resolved version of Typescript didn't actually change and was still the thing making it possible to compile. As a result we should explicitly upgrade Typescript to avoid confusion.
